### PR TITLE
Fix links to exercises 

### DIFF
--- a/source/06-built_in_classes/01-numbers.md
+++ b/source/06-built_in_classes/01-numbers.md
@@ -50,5 +50,5 @@ $irb
 => 1.5
 ```
 
-Exercises: How about doing some of the [exercises on numbers](/16-exercises/01-numbers.html)
+Exercises: How about doing some of the [exercises on numbers](/17-exercises/01-numbers.html)
 next?

--- a/source/06-built_in_classes/02-strings.md
+++ b/source/06-built_in_classes/02-strings.md
@@ -89,5 +89,5 @@ Some other things that you can do with strings that you can try yourself in
 => "olleh"
 ```
 
-Exercises: How about doing some of the [exercises on strings](/16-exercises/02-strings.html)
+Exercises: How about doing some of the [exercises on strings](/17-exercises/02-strings.html)
 next?

--- a/source/06-built_in_classes/04-arrays.md
+++ b/source/06-built_in_classes/04-arrays.md
@@ -83,4 +83,4 @@ On formatting: Note that there are no spaces inside the square brackets,
 and there's one space after each comma.
 
 Exercises: Now would be a good time to do some of the [exercises on
-arrays](/16-exercises/03-arrays_1.html).
+arrays](/17-exercises/03-arrays_1.html).

--- a/source/06-built_in_classes/05-hashes.md
+++ b/source/06-built_in_classes/05-hashes.md
@@ -97,4 +97,4 @@ what it means. Simply remember that these two hashes are exactly the same:
 ```
 
 Exercises: Now would be a good time to do some of the [exercises on
-arrays](/16-exercises/04-hashes_1.html).
+arrays](/17-exercises/04-hashes_1.html).


### PR DESCRIPTION
In the section "Builtin Classes", the exercises links are broken (for instance at http://ruby-for-beginners.rubymonstas.org/06-built_in_classes/01-numbers.html). This PR fixes the broken links.

There is an issue (#5) for this on GitHub.
