### PR TITLE
Point bin/publish at the right repo

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -13,9 +13,9 @@ function run() {
 function setup() {
   run "mkdir -p build"
   run "$git init"
-  run "$git remote add origin git@github.com:rubymonsters/webapps-for-beginners.git"
-  # run "$git fetch"
-  # run "$git reset --hard origin/gh-pages"
+  run "$git remote add origin git@github.com:rubymonsters/ruby-for-beginners.git"
+  run "$git fetch"
+  run "$git reset --hard origin/gh-pages"
 }
 
 function commit() {
@@ -45,4 +45,3 @@ fi
 
 compile
 push
-


### PR DESCRIPTION
The publish script was set up to push to webapps-for-beginners, instead of
ruby-for-beginners.